### PR TITLE
Define symbolic methods and their derivatives for more functions

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 1.0
 Lazy v0.13.1
 DataStructures v0.14.0
 Match v1.0.1
+DiffRules v0.0.7

--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ Lazy v0.13.1
 DataStructures v0.14.0
 Match v1.0.1
 DiffRules v0.0.7
+SpecialFunctions v0.7.1

--- a/src/Calculus.jl
+++ b/src/Calculus.jl
@@ -87,11 +87,11 @@ for (M, f, arity) in DiffRules.diffrules()
         @eval begin
             $M.$f(Dx::Differential) = unaryOp($f, x->$deriv)(Dx)
         end
-    elseif arity == 2 && (M == :Base || M == :SpecialFunctions) && f ∉ [:+, :-, :*, :/]
-        deriv = DiffRules.diffrule(M, f, :x, :y)
-        @eval begin
-            $M.$f(Dx::Differential, Dy::Differential) = binaryOp($f, (x, y)->$deriv)(Dx, Dy)
-        end
+    # elseif arity == 2 && (M == :Base || M == :SpecialFunctions) && f ∉ [:+, :-, :*, :/]
+    #     deriv = DiffRules.diffrule(M, f, :x, :y)
+    #     @eval begin
+    #         $M.$f(Dx::Differential, Dy::Differential) = binaryOp($f, (x, y)->$deriv)(Dx, Dy)
+    #     end
     end
 end
 

--- a/src/Calculus.jl
+++ b/src/Calculus.jl
@@ -81,11 +81,13 @@ Base.:^(Dx::Differential,y::Int) = unaryOp(Dx -> Dx^y, Dx -> y*Dx^(y-1))(Dx)
 Base.:^(x::Number,Dy::Differential) = unaryOp(Dy -> x^Dy, Dy -> log(x)*x^Dy)(Dy)
 
 # overloading some Base math functions for Symbolics.Differential
-for f in [:exp, :log, :sqrt, :sin, :cos]
-    deriv = DiffRules.diffrule(:Base, f, :x)
-    @eval begin
-       Base.$f(Dx::Symbolics.Differential) = Symbolics.unaryOp($f, x->$deriv)(Dx)
-   end
+for (M, f, arity) in DiffRules.diffrules()
+    if arity == 1 && M == :Base
+        deriv = DiffRules.diffrule(M, f, :x)
+        @eval begin
+            $M.$f(Dx::Symbolics.Differential) = Symbolics.unaryOp($f, x->$deriv)(Dx)
+        end
+    end
 end
 
 #---------------------------------------------------------------

--- a/src/Calculus.jl
+++ b/src/Calculus.jl
@@ -1,4 +1,6 @@
 # [[file:~/Documents/Julia/scrap.org::*Calculus.jl][Calculus.jl:1]]
+
+Base.adjoint(Dx::Differential) = Differential(tag => adjoint(value) for (tag, value) in Dx.terms)
 #---------------------------------------------------------------
 #---------------------------------------------------------------
 # Addition of Differentials
@@ -48,6 +50,9 @@ function Base.:*(t1::DTag,t2::DTag)
     end
 end
 
+Base.one(Dx::Differential)  = 1.0
+Base.zero(Dx::Differential) = 0.0
+
 #---------------------------------------------------------------
 #---------------------------------------------------------------
 # constructors for new unary and binary operations
@@ -59,8 +64,20 @@ function unaryOp(f::T, Df::U) where {T<:Union{Function,SymExpr},U<:Union{Functio
 end
 
 function binaryOp(f::Function, Dfx::Function, Dfy::Function)
-    function (Dx::Differential, Dy::Differential)
-        f(Dx[1:end-1],Dy[1:end-1]) + Dfx(Dx[1:end-1], Dy[1:end-1])*Dx[end] + Dfy(Dx[1:end-1], Dy[1:end-1])*Dy[end]
+    function (x, y)
+        if (x isa Differential) && (y isa Differential)
+            Dx = x
+            Dy = y;
+            f(Dx[1:end-1],Dy[1:end-1]) + Dfx(Dx[1:end-1], Dy[1:end-1])*Dx[end] + Dfy(Dx[1:end-1], Dy[1:end-1])*Dy[end]
+        elseif  (x isa Differential)
+            Dx = x
+            f(Dx[1:end-1],y) + Dfx(Dx[1:end-1], y)*Dx[end]
+        elseif y isa Differential
+            Dy = y
+            f(x,Dy[1:end-1]) + Dfy(x, Dy[1:end-1])*Dy[end]
+        else
+            throw("one of two arguments must be a differential")
+        end
     end
 end
 
@@ -71,18 +88,74 @@ Base.:-(Dx::Differential, Dy::Differential) = binaryOp((x,y) -> x - y,
                                                        (x,y) -> -1)(Dx,Dy)
 
 Base.:/(Dx::Differential,y::Number) = unaryOp(Dx -> Dx/y, Dx -> 1/y)(Dx)
-Base.:/(x::Number,Dy::Differential) = unaryOp(Dy -> x/Dy, Dy -> -1/(Dy)^2)(Dy)
+Base.:/(x::Number,Dy::Differential) = unaryOp(Dy -> x/Dy, Dy -> -x/(Dy)^2)(Dy)
 Base.:/(Dx::Differential,Dy::Differential) = binaryOp((x,y) -> x/y,
                                                       (x,y) -> 1/y,
                                                       (x,y) -> -x/y^2)(Dx,Dy)
+Base.inv(Dx::Differential) = 1/Dx
 
 Base.:^(Dx::Differential,y::Number) = unaryOp(Dx -> Dx^y, Dx -> y*Dx^(y-1))(Dx)
 Base.:^(Dx::Differential,y::Int) = unaryOp(Dx -> Dx^y, Dx -> y*Dx^(y-1))(Dx)
 Base.:^(x::Number,Dy::Differential) = unaryOp(Dy -> x^Dy, Dy -> log(x)*x^Dy)(Dy)
 
 # Define differentiation rules for most Base and SpecialFunctions math functions
+
+# Base.:(\ )(x::Differential,y::Number) = inv(x)*y
+# Base.:(\ )(x::Number,y::Differential) = inv(x)*y
+# Base.:(\ )(x::Differential,y::Differential) = inv(x)*y
+
+
+function Base.atan(Dx::Union{Number,Differential}, Dy::Union{Number,Differential})
+    binaryOp(atan,
+             (x,y) ->  y/(x^2 + y^2),
+             (x,y) -> -x/(x^2 + y^2))(Dx, Dy)
+end
+
+function Base.hypot(Dx::Union{Number,Differential}, Dy::Union{Number,Differential})
+    binaryOp(hypot,
+             (x,y) ->  x/hypot(x,y),
+             (x,y) ->  y/hypot(x,y))(Dx,Dy)
+end
+
+function SpecialFunctions.besselj(ν, Dx::Differential)
+    unaryOp(x -> besselj(ν,x), x ->(besselj(ν - 1, x) - besselj(ν + 1, x))/2)(Dx)
+end
+function SpecialFunctions.besseli(ν, Dx::Differential)
+    unaryOp(x -> besseli(ν,x), x ->(besseli(ν - 1, x) + besseli(ν + 1, x))/2)(Dx)
+end
+function SpecialFunctions.bessely(ν, Dx::Differential)
+    unaryOp(x -> bessely(ν,x), x ->(bessely(ν - 1, x) - bessely(ν + 1, x))/2)(Dx)
+end
+function SpecialFunctions.besselk(ν, Dx::Differential)
+    unaryOp(x -> besselk(ν,x), x ->(besselk(ν - 1, x) + besselk(ν + 1, x))/2)(Dx)
+end
+function SpecialFunctions.hankelh1(ν, Dx::Differential)
+    unaryOp(x -> hankelh1(ν,x), x ->(hankelh1(ν - 1, x) - hankelh1(ν + 1, x))/2)(Dx)
+end
+
+function SpecialFunctions.hankelh2(ν, Dx::Differential)
+    unaryOp(x -> hankelh2(ν,x), x ->(hankelh2(ν - 1, x) - hankelh2(ν + 1, x))/2)(Dx)
+end
+
+function SpecialFunctions.polygamma(m, Dx::Differential)
+    unaryOp(x -> polygamma(m,x), x -> polygamma(m + 1, x))(Dx)
+end
+
+function SpecialFunctions.beta(Dx::Union{Number,Differential}, Dy::Union{Number,Differential})
+    binaryOp(beta,
+             (x,y) -> beta(x,y)*(digamma(x)-digamma(x+y)),
+             (x,y) -> beta(x,y)*(digamma(y)-digamma(x+y)))(Dx,Dy)
+end
+
+function SpecialFunctions.lbeta(Dx::Union{Number,Differential}, Dy::Union{Number,Differential})
+    binaryOp(lbeta,
+             (x,y) -> digamma(x)-digamma(x+y),
+             (x,y) -> digamma(y)-digamma(x+y))(Dx,Dy)
+end
+
+
 for (M, f, arity) in DiffRules.diffrules()
-    if arity == 1 && (M == :Base || M == :SpecialFunctions) && f ∉ [:inv, :+, :-, :abs, :trigamma, :digamma, :invdigamma, :gamma, :lgamma] # [:bessely0, :besselj0, :bessely1, :besselj1]
+    if arity == 1 && (M == :Base || M == :SpecialFunctions) && f ∉ [:inv, :+, :-, :abs] # [:bessely0, :besselj0, :bessely1, :besselj1]
         deriv = DiffRules.diffrule(M, f, :x)
         @eval begin
             $M.$f(Dx::Differential) = unaryOp($f, x->$deriv)(Dx)

--- a/src/Calculus.jl
+++ b/src/Calculus.jl
@@ -80,17 +80,17 @@ Base.:^(Dx::Differential,y::Number) = unaryOp(Dx -> Dx^y, Dx -> y*Dx^(y-1))(Dx)
 Base.:^(Dx::Differential,y::Int) = unaryOp(Dx -> Dx^y, Dx -> y*Dx^(y-1))(Dx)
 Base.:^(x::Number,Dy::Differential) = unaryOp(Dy -> x^Dy, Dy -> log(x)*x^Dy)(Dy)
 
-# overloading some Base math functions for Symbolics.Differential
+# Define differentiation rules for most Base and SpecialFunctions math functions
 for (M, f, arity) in DiffRules.diffrules()
-    if arity == 1 && (M == :Base || M == :SpecialFunctions)
+    if arity == 1 && (M == :Base || M == :SpecialFunctions) && f ∉ [:inv, :+, :-, :abs, :trigamma, :digamma, :invdigamma, :gamma, :lgamma] # [:bessely0, :besselj0, :bessely1, :besselj1]
         deriv = DiffRules.diffrule(M, f, :x)
         @eval begin
-            $M.$f(Dx::Symbolics.Differential) = Symbolics.unaryOp($f, x->$deriv)(Dx)
+            $M.$f(Dx::Differential) = unaryOp($f, x->$deriv)(Dx)
         end
-    elseif arity == 2 && (M == :Base || M == :SpecialFunctions)
+    elseif arity == 2 && (M == :Base || M == :SpecialFunctions) && f ∉ [:+, :-, :*, :/]
         deriv = DiffRules.diffrule(M, f, :x, :y)
         @eval begin
-            $M.$f(Dx::Differential, Dy::Differential) = Symbolics.binaryOp($f, (x, y)->$deriv)(Dx, Dy)
+            $M.$f(Dx::Differential, Dy::Differential) = binaryOp($f, (x, y)->$deriv)(Dx, Dy)
         end
     end
 end

--- a/src/Calculus.jl
+++ b/src/Calculus.jl
@@ -80,15 +80,13 @@ Base.:^(Dx::Differential,y::Number) = unaryOp(Dx -> Dx^y, Dx -> y*Dx^(y-1))(Dx)
 Base.:^(Dx::Differential,y::Int) = unaryOp(Dx -> Dx^y, Dx -> y*Dx^(y-1))(Dx)
 Base.:^(x::Number,Dy::Differential) = unaryOp(Dy -> x^Dy, Dy -> log(x)*x^Dy)(Dy)
 
-Base.exp(Dx::Differential) = unaryOp(exp, exp)(Dx)
-
-Base.log(Dx::Differential) = unaryOp(log, x -> 1/x)(Dx)
-
-Base.sqrt(Dx::Differential) = unaryOp(sqrt, x -> 1/(2*sqrt(x)))(Dx)
-
-Base.sin(Dx::Differential) = unaryOp(sin, x -> cos(x))(Dx)
-
-Base.cos(Dx::Differential) = unaryOp(cos, x -> -sin(x))(Dx)
+# overloading some Base math functions for Symbolics.Differential
+for f in [:exp, :log, :sqrt, :sin, :cos]
+    deriv = DiffRules.diffrule(:Base, f, :x)
+    @eval begin
+       Base.$f(Dx::Symbolics.Differential) = Symbolics.unaryOp($f, x->$deriv)(Dx)
+   end
+end
 
 #---------------------------------------------------------------
 #---------------------------------------------------------------

--- a/src/Calculus.jl
+++ b/src/Calculus.jl
@@ -87,6 +87,11 @@ for (M, f, arity) in DiffRules.diffrules()
         @eval begin
             $M.$f(Dx::Symbolics.Differential) = Symbolics.unaryOp($f, x->$deriv)(Dx)
         end
+    elseif arity == 2 && (M == :Base || M == :SpecialFunctions)
+        deriv = DiffRules.diffrule(M, f, :x, :y)
+        @eval begin
+            $M.$f(Dx::Differential, Dy::Differential) = Symbolics.binaryOp($f, (x, y)->$deriv)(Dx, Dy)
+        end
     end
 end
 

--- a/src/Calculus.jl
+++ b/src/Calculus.jl
@@ -82,7 +82,7 @@ Base.:^(x::Number,Dy::Differential) = unaryOp(Dy -> x^Dy, Dy -> log(x)*x^Dy)(Dy)
 
 # overloading some Base math functions for Symbolics.Differential
 for (M, f, arity) in DiffRules.diffrules()
-    if arity == 1 && M == :Base
+    if arity == 1 && (M == :Base || M == :SpecialFunctions)
         deriv = DiffRules.diffrule(M, f, :x)
         @eval begin
             $M.$f(Dx::Symbolics.Differential) = Symbolics.unaryOp($f, x->$deriv)(Dx)

--- a/src/Calculus.jl
+++ b/src/Calculus.jl
@@ -1,3 +1,6 @@
+# Calculus.jl
+
+
 # [[file:~/Documents/Julia/scrap.org::*Calculus.jl][Calculus.jl:1]]
 
 Base.adjoint(Dx::Differential) = Differential(tag => adjoint(value) for (tag, value) in Dx.terms)

--- a/src/SymbolicAlgebra.jl
+++ b/src/SymbolicAlgebra.jl
@@ -54,6 +54,10 @@ Base.abs(x::T) where {T<:Symbolic} = sqrt(x^2)
 Base.conj(x::Union{AbstractSymExpr,AbstractSym}) = x
 
 
+promote_SymForm(x::Number, y::Union{Sym,SymExpr}) = SymExpr
+promote_SymForm(x::Union{Sym,SymExpr}, y::Number) = SymExpr
+promote_SymForm(x::Union{Sym,SymExpr}, y::Union{Sym,SymExpr}) = SymExpr
+
 
 SymNum = Union{Symbolic,Number}
 

--- a/src/SymbolicAlgebra.jl
+++ b/src/SymbolicAlgebra.jl
@@ -59,19 +59,27 @@ promote_SymForm(x::Union{Sym,SymExpr}, y::Number) = SymExpr
 promote_SymForm(x::Union{Sym,SymExpr}, y::Union{Sym,SymExpr}) = SymExpr
 
 
+
 SymNum = Union{Symbolic,Number}
 
 function Base.atan(x::T, y::V) where {T<:SymNum,V<:SymNum} 
    promote_SymForm(x,y)(:atan, stripiden.([x,y]))
 end
     
-function Base.hypot(x::T, y::V) where {T<:SymNum,V<:SymNum} 
+function Base.hypot(x::T, y::V) where {T<:Symbolic,V<:Symbolic} 
+   promote_SymForm(x,y)(:hypot, stripiden.([x,y]))
+end
+function Base.hypot(x::T, y::V) where {T<:Number,V<:Symbolic} 
+   promote_SymForm(x,y)(:hypot, stripiden.([x,y]))
+end
+function Base.hypot(x::T, y::V) where {T<:Symbolic,V<:Number} 
    promote_SymForm(x,y)(:hypot, stripiden.([x,y]))
 end
 
 function Base.max(x::T, y::V) where {T<:SymNum,V<:SymNum} 
     promote_SymForm(x,y)(:max, stripiden.([x,y]))
 end
+
 
 function Base.min(x::T, y::V) where {T<:SymNum,V<:SymNum} 
     promote_SymForm(x,y)(:min, stripiden.([x,y]))
@@ -123,8 +131,14 @@ function SpecialFunctions.beta(a::T, b::V) where {T<:Symbolic,V<:Symbolic}
     promote_SymForm(a,b)(:beta, stripiden.([a, b]))
 end
 
-function SpecialFunctions.lbeta(a::T, b::V) where {T<:SymNum,V<:SymNum} 
-    promote_SymForm(a,b)(:lbeta, stripiden.([a, b]))
+function SpecialFunctions.beta(a::T, b::V) where {T<:Number,V<:Symbolic} 
+    promote_SymForm(a,b)(:beta, stripiden.([a, b]))
+end
+function SpecialFunctions.beta(a::T, b::V) where {T<:Symbolic,V<:Number} 
+    promote_SymForm(a,b)(:beta, stripiden.([a, b]))
+end
+function SpecialFunctions.beta(a::T, b::V) where {T<:Symbolic,V<:Symbolic} 
+    promote_SymForm(a,b)(:beta, stripiden.([a, b]))
 end
 
 

--- a/src/SymbolicAlgebra.jl
+++ b/src/SymbolicAlgebra.jl
@@ -37,14 +37,13 @@ Base.zero(a::Symbolic) = 0
 # Division
 Base.:(/)(x::T, y::T) where {T<:Symbolic} = promote(T)(:*, stripiden.([x, y^-1]))  |> simplify
 
-
 #_____________________________________________
 # Exponents
 Base.:(^)(x::T, y::T) where {T<:Symbolic}   = promote(T)(:^, stripiden.([x, y]))  |> simplify
 Base.:(^)(x::T, y::Int) where {T<:Symbolic} = promote(T)(:^, stripiden.([x, y]))  |> simplify
-Base.exp(x::T) where {T<:Symbolic} = promote(T)(:exp, stripiden.([x]))  |> simplify
+# Base.exp(x::T) where {T<:Symbolic} = promote(T)(:exp, stripiden.([x]))  |> simplify
 
-Base.sqrt(x::T) where {T<:Symbolic} = promote(T)(:sqrt, stripiden.([x]))  |> simplify
+# Base.sqrt(x::T) where {T<:Symbolic} = promote(T)(:sqrt, stripiden.([x]))  |> simplify
 
 #_____________________________________________
 # inv
@@ -52,11 +51,29 @@ Base.inv(x::T) where {T<:Symbolic} = promote(T)(:^, stripiden.([x, -1]))  |> sim
 
 #_____________________________________________
 # Logarithms
-Base.log(x::T) where {T<:Symbolic} = promote(T)(:log, stripiden.([x]))  |> simplify
+# Base.log(x::T) where {T<:Symbolic} = promote(T)(:log, stripiden.([x]))  |> simplify
 
 #_____________________________________________
 # Trig
-Base.cos(x::T) where {T<:Symbolic} = promote(T)(:cos, stripiden.([x]))  |> simplify
-Base.sin(x::T) where {T<:Symbolic} = promote(T)(:sin, stripiden.([x]))  |> simplify
-Base.tan(x::T) where {T<:Symbolic} = promote(T)(:tan, stripiden.([x]))  |> simplify
+# Base.cos(x::T) where {T<:Symbolic} = promote(T)(:cos, stripiden.([x]))  |> simplify
+# Base.sin(x::T) where {T<:Symbolic} = promote(T)(:sin, stripiden.([x]))  |> simplify
+# Base.tan(x::T) where {T<:Symbolic} = promote(T)(:tan, stripiden.([x]))  |> simplify
+
+Base.abs(x::T) where {T<:Symbolic} = sqrt(x^2)
+
+#_____________________________________________
+# More math functions
+for (M, f, arity) in DiffRules.diffrules()
+    if arity == 1 && (M == :Base || M == :SpecialFunctions) && f ∉ [:inv, :+, :-, :abs, :trigamma, :digamma, :invdigamma, :gamma, :lgamma] # [:bessely0, :besselj0, :bessely1, :besselj1]
+        deriv = DiffRules.diffrule(M, f, :x)
+        @eval begin
+            $M.$f(x::T) where {T<:Symbolic} = promote(T)(Symbol($f), stripiden.([x]))  |> simplify
+        end
+    elseif arity == 2 && (M == :Base || M == :SpecialFunctions) && f ∉ [:+, :-, :*, :/, :^]
+        deriv = DiffRules.diffrule(M, f, :x, :y)
+        @eval begin
+            $M.$f(x::T, y::T) where {T<:Symbolic} = promote(T)(Symbol($f), stripiden.([x, y]))  |> simplify
+        end
+    end
+end
 # SymbolicAlgebra.jl:1 ends here

--- a/src/SymbolicAlgebra.jl
+++ b/src/SymbolicAlgebra.jl
@@ -53,29 +53,81 @@ Base.abs(x::T) where {T<:Symbolic} = sqrt(x^2)
 
 Base.conj(x::Union{AbstractSymExpr,AbstractSym}) = x
 
-Base.atan(x::T, y::T) where {T<:Symbolic} = promote(T)(:atan, stripiden.([x,y]))
-Base.hypot(x::T, y::T) where {T<:Symbolic} = promote(T)(:hypot, stripiden.([x,y]))
-Base.max(x::T, y::T) where {T<:Symbolic} = promote(T)(:max, stripiden.([x,y]))
-Base.min(x::T, y::T) where {T<:Symbolic} = promote(T)(:min, stripiden.([x,y]))
 
 
-SpecialFunctions.besselj(ν::T, x::T) where {T<:Symbolic} = promote(T)(:besselj, stripiden.([ν, x]))
-SpecialFunctions.besseli(ν::T, x::T) where {T<:Symbolic} = promote(T)(:besseli, stripiden.([ν, x]))
-SpecialFunctions.besselk(ν::T, x::T) where {T<:Symbolic} = promote(T)(:besselk, stripiden.([ν, x]))
-SpecialFunctions.hankelh1(ν::T, x::T) where {T<:Symbolic} = promote(T)(:hankelh1, stripiden.([ν, x]))
-SpecialFunctions.hankelh2(ν::T, x::T) where {T<:Symbolic} = promote(T)(:hankelh2, stripiden.([ν, x]))
-SpecialFunctions.bessely(ν::T, x::T) where {T<:Symbolic} = promote(T)(:bessely, stripiden.([ν, x]))
-SpecialFunctions.polygamma(m::T, x::T) where {T<:Symbolic} = promote(T)(:polygamma, stripiden.([m, x]))
-SpecialFunctions.beta(a::T, b::T) where {T<:Symbolic} = promote(T)(:beta, stripiden.([a, b]))
-SpecialFunctions.lbeta(a::T, b::T) where {T<:Symbolic} = promote(T)(:lbeta, stripiden.([a, b]))
+SymNum = Union{Symbolic,Number}
 
-SpecialFunctions.besselj(ν::Int, x::T) where {T<:Symbolic} = promote(T)(:besselj, stripiden.([ν, x]))
-SpecialFunctions.bessely(ν::Int, x::T) where {T<:Symbolic} = promote(T)(:bessely, stripiden.([ν, x]))
+function Base.atan(x::T, y::V) where {T<:SymNum,V<:SymNum} 
+   promote_SymForm(x,y)(:atan, stripiden.([x,y]))
+end
+    
+function Base.hypot(x::T, y::V) where {T<:SymNum,V<:SymNum} 
+   promote_SymForm(x,y)(:hypot, stripiden.([x,y]))
+end
+
+function Base.max(x::T, y::V) where {T<:SymNum,V<:SymNum} 
+    promote_SymForm(x,y)(:max, stripiden.([x,y]))
+end
+
+function Base.min(x::T, y::V) where {T<:SymNum,V<:SymNum} 
+    promote_SymForm(x,y)(:min, stripiden.([x,y]))
+end
+
+function Base.:<(x::T, y::V) where {T<:SymNum,V<:SymNum} 
+    promote_SymForm(x,y)(:<, stripiden.([x,y]))
+end
+
+function SpecialFunctions.besselj(ν::T, x::V) where {T<:SymNum,V<:SymNum} 
+    promote_SymForm(ν,x)(:besselj, stripiden.([ν, x]))
+end
+
+function SpecialFunctions.besseli(ν::T, x::V) where {T<:SymNum,V<:SymNum} 
+    promote_SymForm(ν,x)(:besseli, stripiden.([ν, x]))
+end
+
+function SpecialFunctions.bessely(ν::T, x::V) where {T<:SymNum,V<:SymNum} 
+    promote_SymForm(ν,x)(:bessely, stripiden.([ν, x]))
+end
+
+function SpecialFunctions.besselk(ν::T, x::V) where {T<:SymNum,V<:SymNum} 
+    promote_SymForm(ν,x)(:besselk, stripiden.([ν, x]))
+end
+
+function SpecialFunctions.hankelh1(ν::T, x::V) where {T<:SymNum,V<:SymNum} 
+    promote_SymForm(ν,x)(:hankelh1, stripiden.([ν, x]))
+end
+
+function SpecialFunctions.hankelh2(ν::T, x::V) where {T<:SymNum,V<:SymNum} 
+    promote_SymForm(ν,x)(:hankelh2, stripiden.([ν, x]))
+end
+
+function SpecialFunctions.polygamma(m::T, x::V) where {T<:SymNum,V<:SymNum} 
+    promote_SymForm(m,x)(:polygamma, stripiden.([m, x]))
+end
+function SpecialFunctions.polygamma(m::Int, x::V) where {V<:SymNum} 
+    promote_SymForm(m,x)(:polygamma, stripiden.([m, x]))
+end
+
+
+function SpecialFunctions.beta(a::T, b::V) where {T<:Number,V<:Symbolic} 
+    promote_SymForm(a,b)(:beta, stripiden.([a, b]))
+end
+function SpecialFunctions.beta(a::T, b::V) where {T<:Symbolic,V<:Number} 
+    promote_SymForm(a,b)(:beta, stripiden.([a, b]))
+end
+function SpecialFunctions.beta(a::T, b::V) where {T<:Symbolic,V<:Symbolic} 
+    promote_SymForm(a,b)(:beta, stripiden.([a, b]))
+end
+
+function SpecialFunctions.lbeta(a::T, b::V) where {T<:SymNum,V<:SymNum} 
+    promote_SymForm(a,b)(:lbeta, stripiden.([a, b]))
+end
+
 
 #_____________________________________________
 # More math functions
 for (M, f, arity) in DiffRules.diffrules()
-    if arity == 1 && (M == :Base || M == :SpecialFunctions) && f ∉ [:inv, :+, :-, :abs, :trigamma, :digamma, :invdigamma, :gamma, :lgamma] # [:bessely0, :besselj0, :bessely1, :besselj1]
+    if arity == 1 && (M == :Base || M == :SpecialFunctions) && f ∉ [:inv, :+, :-, :abs] # [:bessely0, :besselj0, :bessely1, :besselj1]
         deriv = DiffRules.diffrule(M, f, :x)
         @eval begin
             $M.$f(x::T) where {T<:Symbolic} = promote(T)(Symbol($f), stripiden.([x]))  |> simplify

--- a/src/SymbolicAlgebra.jl
+++ b/src/SymbolicAlgebra.jl
@@ -69,6 +69,9 @@ SpecialFunctions.polygamma(m::T, x::T) where {T<:Symbolic} = promote(T)(:polygam
 SpecialFunctions.beta(a::T, b::T) where {T<:Symbolic} = promote(T)(:beta, stripiden.([a, b]))
 SpecialFunctions.lbeta(a::T, b::T) where {T<:Symbolic} = promote(T)(:lbeta, stripiden.([a, b]))
 
+SpecialFunctions.besselj(ν::Int, x::T) where {T<:Symbolic} = promote(T)(:besselj, stripiden.([ν, x]))
+SpecialFunctions.bessely(ν::Int, x::T) where {T<:Symbolic} = promote(T)(:bessely, stripiden.([ν, x]))
+
 #_____________________________________________
 # More math functions
 for (M, f, arity) in DiffRules.diffrules()

--- a/src/SymbolicAlgebra.jl
+++ b/src/SymbolicAlgebra.jl
@@ -131,14 +131,14 @@ function SpecialFunctions.beta(a::T, b::V) where {T<:Symbolic,V<:Symbolic}
     promote_SymForm(a,b)(:beta, stripiden.([a, b]))
 end
 
-function SpecialFunctions.beta(a::T, b::V) where {T<:Number,V<:Symbolic} 
-    promote_SymForm(a,b)(:beta, stripiden.([a, b]))
+function SpecialFunctions.lbeta(a::T, b::V) where {T<:Number,V<:Symbolic} 
+    promote_SymForm(a,b)(:lbeta, stripiden.([a, b]))
 end
-function SpecialFunctions.beta(a::T, b::V) where {T<:Symbolic,V<:Number} 
-    promote_SymForm(a,b)(:beta, stripiden.([a, b]))
+function SpecialFunctions.lbeta(a::T, b::V) where {T<:Symbolic,V<:Number} 
+    promote_SymForm(a,b)(:lbeta, stripiden.([a, b]))
 end
-function SpecialFunctions.beta(a::T, b::V) where {T<:Symbolic,V<:Symbolic} 
-    promote_SymForm(a,b)(:beta, stripiden.([a, b]))
+function SpecialFunctions.lbeta(a::T, b::V) where {T<:Symbolic,V<:Symbolic} 
+    promote_SymForm(a,b)(:lbeta, stripiden.([a, b]))
 end
 
 

--- a/src/SymbolicAlgebra.jl
+++ b/src/SymbolicAlgebra.jl
@@ -41,25 +41,21 @@ Base.:(/)(x::T, y::T) where {T<:Symbolic} = promote(T)(:*, stripiden.([x, y^-1])
 # Exponents
 Base.:(^)(x::T, y::T) where {T<:Symbolic}   = promote(T)(:^, stripiden.([x, y]))  |> simplify
 Base.:(^)(x::T, y::Int) where {T<:Symbolic} = promote(T)(:^, stripiden.([x, y]))  |> simplify
-# Base.exp(x::T) where {T<:Symbolic} = promote(T)(:exp, stripiden.([x]))  |> simplify
-
-# Base.sqrt(x::T) where {T<:Symbolic} = promote(T)(:sqrt, stripiden.([x]))  |> simplify
 
 #_____________________________________________
-# inv
+# other
 Base.inv(x::T) where {T<:Symbolic} = promote(T)(:^, stripiden.([x, -1]))  |> simplify
 
-#_____________________________________________
-# Logarithms
-# Base.log(x::T) where {T<:Symbolic} = promote(T)(:log, stripiden.([x]))  |> simplify
-
-#_____________________________________________
-# Trig
-# Base.cos(x::T) where {T<:Symbolic} = promote(T)(:cos, stripiden.([x]))  |> simplify
-# Base.sin(x::T) where {T<:Symbolic} = promote(T)(:sin, stripiden.([x]))  |> simplify
-# Base.tan(x::T) where {T<:Symbolic} = promote(T)(:tan, stripiden.([x]))  |> simplify
+Base.:(\)(x::T,y::T) where {T<:Symbolic} = inv(x)*y
 
 Base.abs(x::T) where {T<:Symbolic} = sqrt(x^2)
+
+Base.conj(x::AbstractSym) = x
+Base.conj(x::AbstractSymExpr) = x
+
+SpecialFunctions.bessely(a, x::T) where {T<:Symbolic} = promote(T)(:bessely, stripiden.([a, x])) 
+SpecialFunctions.besselj(a, x::T) where {T<:Symbolic} = promote(T)(:besselj, stripiden.([a, x]))
+
 
 #_____________________________________________
 # More math functions
@@ -69,11 +65,11 @@ for (M, f, arity) in DiffRules.diffrules()
         @eval begin
             $M.$f(x::T) where {T<:Symbolic} = promote(T)(Symbol($f), stripiden.([x]))  |> simplify
         end
-    elseif arity == 2 && (M == :Base || M == :SpecialFunctions) && f ∉ [:+, :-, :*, :/, :^]
-        deriv = DiffRules.diffrule(M, f, :x, :y)
-        @eval begin
-            $M.$f(x::T, y::T) where {T<:Symbolic} = promote(T)(Symbol($f), stripiden.([x, y]))  |> simplify
-        end
+    # elseif arity == 2 && (M == :Base || M == :SpecialFunctions) && f ∉ [:+, :-, :*, :/, :^]
+    #     deriv = DiffRules.diffrule(M, f, :x, :y)
+    #     @eval begin
+    #         $M.$f(x::T, y::T) where {T<:Symbolic} = promote(T)(Symbol($f), stripiden.([x, y]))  |> simplify
+    #     end
     end
 end
 # SymbolicAlgebra.jl:1 ends here

--- a/src/SymbolicAlgebra.jl
+++ b/src/SymbolicAlgebra.jl
@@ -42,20 +42,32 @@ Base.:(/)(x::T, y::T) where {T<:Symbolic} = promote(T)(:*, stripiden.([x, y^-1])
 Base.:(^)(x::T, y::T) where {T<:Symbolic}   = promote(T)(:^, stripiden.([x, y]))  |> simplify
 Base.:(^)(x::T, y::Int) where {T<:Symbolic} = promote(T)(:^, stripiden.([x, y]))  |> simplify
 
+
 #_____________________________________________
 # other
 Base.inv(x::T) where {T<:Symbolic} = promote(T)(:^, stripiden.([x, -1]))  |> simplify
 
-Base.:(\)(x::T,y::T) where {T<:Symbolic} = inv(x)*y
+Base.:( \ )(x::T,y::T) where {T<:Symbolic} = inv(x)*y
 
 Base.abs(x::T) where {T<:Symbolic} = sqrt(x^2)
 
-Base.conj(x::AbstractSym) = x
-Base.conj(x::AbstractSymExpr) = x
+Base.conj(x::Union{AbstractSymExpr,AbstractSym}) = x
 
-SpecialFunctions.bessely(a, x::T) where {T<:Symbolic} = promote(T)(:bessely, stripiden.([a, x])) 
-SpecialFunctions.besselj(a, x::T) where {T<:Symbolic} = promote(T)(:besselj, stripiden.([a, x]))
+Base.atan(x::T, y::T) where {T<:Symbolic} = promote(T)(:atan, stripiden.([x,y]))
+Base.hypot(x::T, y::T) where {T<:Symbolic} = promote(T)(:hypot, stripiden.([x,y]))
+Base.max(x::T, y::T) where {T<:Symbolic} = promote(T)(:max, stripiden.([x,y]))
+Base.min(x::T, y::T) where {T<:Symbolic} = promote(T)(:min, stripiden.([x,y]))
 
+
+SpecialFunctions.besselj(ν::T, x::T) where {T<:Symbolic} = promote(T)(:besselj, stripiden.([ν, x]))
+SpecialFunctions.besseli(ν::T, x::T) where {T<:Symbolic} = promote(T)(:besseli, stripiden.([ν, x]))
+SpecialFunctions.besselk(ν::T, x::T) where {T<:Symbolic} = promote(T)(:besselk, stripiden.([ν, x]))
+SpecialFunctions.hankelh1(ν::T, x::T) where {T<:Symbolic} = promote(T)(:hankelh1, stripiden.([ν, x]))
+SpecialFunctions.hankelh2(ν::T, x::T) where {T<:Symbolic} = promote(T)(:hankelh2, stripiden.([ν, x]))
+SpecialFunctions.bessely(ν::T, x::T) where {T<:Symbolic} = promote(T)(:bessely, stripiden.([ν, x]))
+SpecialFunctions.polygamma(m::T, x::T) where {T<:Symbolic} = promote(T)(:polygamma, stripiden.([m, x]))
+SpecialFunctions.beta(a::T, b::T) where {T<:Symbolic} = promote(T)(:beta, stripiden.([a, b]))
+SpecialFunctions.lbeta(a::T, b::T) where {T<:Symbolic} = promote(T)(:lbeta, stripiden.([a, b]))
 
 #_____________________________________________
 # More math functions

--- a/src/Symbolics.jl
+++ b/src/Symbolics.jl
@@ -6,7 +6,7 @@ using Match
 import Lazy: @>
 # using ForwardDiff
 using DataStructures
-# using Match
+using DiffRules
 
 
 include("types.jl")

--- a/src/Symbolics.jl
+++ b/src/Symbolics.jl
@@ -6,7 +6,7 @@ using Match
 import Lazy: @>
 # using ForwardDiff
 using DataStructures
-using DiffRules
+using DiffRules, SpecialFunctions
 
 
 include("types.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,12 +5,11 @@ using Symbolics, DiffRules, SpecialFunctions, Test
 
 @sym x y z m ω t;
 
-
 @testset "Construction of SymExprs" begin
     @test x(t) == SymExpr(x, [t])
 end
 
-@testset "Algebra" begin
+@testset "                 Algebra" begin
     @test x^2 + x^2 == 2 * x ^ 2
     @test x^2 - x^2 == 0
     @test (2x + y) - 8x == -6x + y
@@ -20,19 +19,19 @@ end
     @test (x^y)^2/x == x^(y*2 - 1)
 end
 
-@testset "Function Algebra" begin
+@testset "        Function Algebra" begin
     f(x) = x^3
     g(x) = x^2
     @test (f + g)(x) == x ^ 3 + x ^ 2
     @test (f * g)(x) == x ^ 3 * x ^ 2
 end
 
-@testset "Replacements" begin
+@testset "            Replacements" begin
     @test (x^2 + 2x)(x => y) == y^2 + 2y
 end
 
 
-@testset "Derivatives" begin
+@testset "             Derivatives" begin
     f(x) = x^3
     g(x) = x^2
     @test D(f+g)(x) |> simplify == 3 * x ^ 2 + 2x
@@ -47,17 +46,17 @@ end
             @eval begin
                 @test D($M.$f)(x) == $deriv
             end
-        elseif arity == 2 && (M == :Base || M == :SpecialFunctions) && f ∉ [:+, :-, :*, :/]
-            deriv = DiffRules.diffrule(M, f, :x, :y)
-            @eval begin
-                @test D($M.$f)(x, y) == $deriv
-                # $M.$f(Dx::Differential, Dy::Differential) = binaryOp($f, (x, y)->$deriv)(Dx, Dy)
-            end
+        # elseif arity == 2 && (M == :Base || M == :SpecialFunctions) && f ∉ [:+, :-, :*, :/]
+        #     deriv = DiffRules.diffrule(M, f, :x, :y)
+        #     @eval begin
+        #         @test D($M.$f)(x, y) == $deriv
+        #         # $M.$f(Dx::Differential, Dy::Differential) = binaryOp($f, (x, y)->$deriv)(Dx, Dy)
+        #     end
         end
     end
 end
 
-@testset "Euler-Lagrange Solver" begin
+@testset "   Euler-Lagrange Solver" begin
     function Γ(w)
        t -> UpTuple((t, w(t), D(w)(t)))
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,8 @@
 # [[file:~/Documents/Julia/scrap.org::*tests][tests:1]]
 using Symbolics, DiffRules, SpecialFunctions, Test
 
-@sym x y z m ω t;
+@sym x y z m ω t ν;
+
 
 @testset "Construction of SymExprs" begin
     @test x(t) == SymExpr(x, [t])
@@ -40,18 +41,33 @@ end
     @test D(x^2 + y^2 + z^2, x) == 2x
     @test D(D(2x*y, x), y) == 2
     # test diff rules
+    @test D(x -> atan(x,y))(x) ==  y/(x^2 + y^2)
+    @test D(y -> atan(x,y))(y) == -x/(x^2 + y^2)
+    @test D(x -> hypot(x,y))(x) == x/hypot(x,y)
+    @test D(y -> hypot(x,y))(y) == y/hypot(x,y)
+    
+    @test D(x -> besselj(ν,x))(x) == (besselj(ν - 1, x) - besselj(ν + 1, x))/2
+    @test D(x -> besseli(ν,x))(x) == (besseli(ν - 1, x) + besseli(ν + 1, x))/2
+    @test D(x -> bessely(ν,x))(x) == (bessely(ν - 1, x) - bessely(ν + 1, x))/2
+    @test D(x -> besselk(ν,x))(x) == (besselk(ν - 1, x) + besselk(ν + 1, x))/2
+    
+    @test D(x -> hankelh1(ν,x))(x) == (hankelh1(ν - 1, x) - hankelh1(ν + 1, x))/2
+    @test D(x -> hankelh2(ν,x))(x) == (hankelh2(ν - 1, x) - hankelh2(ν + 1, x))/2
+    
+    @test D(x -> polygamma(m,x))(x) == polygamma(m + 1, x)
+    
+    @test D(x -> beta(x,y))(x) == beta(x,y)*(digamma(x)-digamma(x+y))
+    @test D(y -> beta(x,y))(y) == beta(x,y)*(digamma(y)-digamma(x+y))
+
+    @test D(x -> lbeta(x,y))(x) == digamma(x)-digamma(x+y)
+    @test D(y -> lbeta(x,y))(y) == digamma(y)-digamma(x+y)
+    
     for (M, f, arity) in DiffRules.diffrules()
-        if arity == 1 && (M == :Base || M == :SpecialFunctions) && f ∉ [:inv, :+, :-, :abs, :trigamma, :digamma, :invdigamma, :gamma, :lgamma] # [:bessely0, :besselj0, :bessely1, :besselj1]
+        if arity == 1 && (M == :Base || M == :SpecialFunctions) && f ∉ [:inv, :+, :-, :abs, ] # [:bessely0, :besselj0, :bessely1, :besselj1]
             deriv = DiffRules.diffrule(M, f, :x)
             @eval begin
                 @test D($M.$f)(x) == $deriv
             end
-        # elseif arity == 2 && (M == :Base || M == :SpecialFunctions) && f ∉ [:+, :-, :*, :/]
-        #     deriv = DiffRules.diffrule(M, f, :x, :y)
-        #     @eval begin
-        #         @test D($M.$f)(x, y) == $deriv
-        #         # $M.$f(Dx::Differential, Dy::Differential) = binaryOp($f, (x, y)->$deriv)(Dx, Dy)
-        #     end
         end
     end
 end


### PR DESCRIPTION
Fixes #6. This is currently work in progress. This PR defines derivatives using DiffRules instead of manual definitions. Started off by substituting current differentiation rules with their equivalencies in DiffRules, and locally tests pass. I think it'd be worthwhile to add more diff rules, as well as corresponding tests.