### PR TITLE
Construct UpTuple/DownTuple as wrappers around Array instead of Tuple

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,10 +15,10 @@ matrix:
   - julia_version: nightly
   - julia_version: 0.7
 
-branches:
-  only:
-    - master
-    - /release-.*/
+# branches:
+#   only:
+#     - master
+#     - /release-.*/
 
 notifications:
   - provider: Email

--- a/src/Calculus.jl
+++ b/src/Calculus.jl
@@ -208,8 +208,7 @@ end
 function ∂(i)
     function (f)
         ϵ = makeDiff()
-        arg -> extractDiff(f(UpTuple(Tuple(i==j ? arg[j]+ϵ
-                                                : arg[j] for j in eachindex(arg)))),ϵ)
+        arg -> extractDiff(f(UpTuple([i==j ? arg[j]+ϵ : arg[j] for j in eachindex(arg)])),ϵ)
     end
 end
 # Calculus.jl:1 ends here

--- a/src/Structure.jl
+++ b/src/Structure.jl
@@ -7,12 +7,12 @@ Base.eachindex(A::UpTuple) = eachindex(A.data)
 square(arr::UpTuple) = [arr.data...]' * [arr.data...]
 square(a::SymExpr) = a^2
 
-Base.:+(A::UpTuple, b) = UpTuple(Tuple(a + b for a in A.data))
-Base.:+(a, B::UpTuple) = UpTuple(Tuple(a + b for b in B.data))
+Base.:+(A::UpTuple, b) = UpTuple([a + b for a in A.data])
+Base.:+(a, B::UpTuple) = UpTuple([a + b for b in B.data])
 
 function Base.:+(A::UpTuple, B::UpTuple)
     if length(A) == length(B)
-        UpTuple(Tuple(a[i] + b[i] for i in eachindex(A)))
+        UpTuple([a[i] + b[i] for i in eachindex(A)])
     end
 end
 # Structure.jl:1 ends here

--- a/src/Symbolics.jl
+++ b/src/Symbolics.jl
@@ -19,7 +19,7 @@ include("FunctionAlgebra.jl")
 include("Structure.jl")
 
 
-export Sym, SymExpr, AbstractSym, AbstractSymExpr, @sym, Symbolic, D, ∂, simplify, UpTuple
+export Sym, SymExpr, AbstractSym, AbstractSymExpr, @sym, Symbolic, D, ∂, simplify, UpTuple, DownTuple
 export up, down, square
 
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -105,12 +105,12 @@ abstract type Structure end
 
 SymOrSymExpr = Union{Sym, SymExpr}
 
-struct UpTuple{T} <: Structure where {T<:SymOrSymExpr}
-    data::Vector{T}
+struct UpTuple <: Structure
+    data::Vector
 end
 
-struct DownTuple{T} <: Structure where {T<:SymOrSymExpr}
-    data::Vector{T}
+struct DownTuple <: Structure
+    data::Vector
 end
 
 function Base.show(io::IO, up::UpTuple)
@@ -129,11 +129,11 @@ function Base.show(io::IO, down::DownTuple)
     print(io, "down$(arr)")
 end
 
-(arr::UpTuple)(t) = UpTuple(arr.(t))
-(arr::DownTuple)(t) = DownTuple(arr.(t))
+(arr::UpTuple)(t) = UpTuple([i(t) for i in arr.data])
+(arr::DownTuple)(t) = DownTuple([i(t) for i in arr.data])
 
-up(data...) = UpTuple(data)
-down(data...) = DownTuple(data)
+up(data) = UpTuple(data)
+down(data) = DownTuple(data)
 
 expand_expression(arr::UpTuple) = up([expand_expression(i) for i in arr.data]...)
 Base.getindex(arr::UpTuple, i::Integer) = getindex(arr.data, i)

--- a/src/types.jl
+++ b/src/types.jl
@@ -5,7 +5,7 @@
 #---------------------------------------------------------------
 # Syms
 abstract type Symbolic <: Number  end
-abstract type AbstractSym <: Symbolic end 
+abstract type AbstractSym <: Symbolic end
 
 struct Sym <: AbstractSym
     name::Symbol
@@ -47,7 +47,7 @@ Base.Symbol(s::AbstractSym) = s.name
 #---------------------------------------------------------------
 #---------------------------------------------------------------
 # SymExprs
-abstract type AbstractSymExpr <: Symbolic end 
+abstract type AbstractSymExpr <: Symbolic end
 struct SymExpr <: AbstractSymExpr
     op::Symbolic
     args::Vector
@@ -103,12 +103,14 @@ Base.eval(a::AbstractSymExpr) = eval(Expr(a))
 
 abstract type Structure end
 
-struct UpTuple <: Structure
-    data::Tuple
+SymOrSymExpr = Union{Sym, SymExpr}
+
+struct UpTuple{T} <: Structure where {T<:SymOrSymExpr}
+    data::Vector{T}
 end
 
-struct DownTuple <: Structure
-    data::Tuple
+struct DownTuple{T} <: Structure where {T<:SymOrSymExpr}
+    data::Vector{T}
 end
 
 function Base.show(io::IO, up::UpTuple)
@@ -127,8 +129,8 @@ function Base.show(io::IO, down::DownTuple)
     print(io, "down$(arr)")
 end
 
-(arr::UpTuple)(t) = UpTuple(Tuple(i(t) for i in arr.data))
-(arr::DownTuple)(t) = DownTuple(Tuple(i(t) for i in arr.data))
+(arr::UpTuple)(t) = UpTuple(arr.(t))
+(arr::DownTuple)(t) = DownTuple(arr.(t))
 
 up(data...) = UpTuple(data)
 down(data...) = DownTuple(data)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,23 +47,23 @@ end
     @test D(y -> atan(x,y))(y) == -x/(x^2 + y^2)
     @test D(x -> hypot(x,y))(x) == x/hypot(x,y)
     @test D(y -> hypot(x,y))(y) == y/hypot(x,y)
-    
+
     @test D(x -> besselj(ν,x))(x) == (besselj(ν - 1, x) - besselj(ν + 1, x))/2
     @test D(x -> besseli(ν,x))(x) == (besseli(ν - 1, x) + besseli(ν + 1, x))/2
     @test D(x -> bessely(ν,x))(x) == (bessely(ν - 1, x) - bessely(ν + 1, x))/2
     @test D(x -> besselk(ν,x))(x) == (besselk(ν - 1, x) + besselk(ν + 1, x))/2
-    
+
     @test D(x -> hankelh1(ν,x))(x) == (hankelh1(ν - 1, x) - hankelh1(ν + 1, x))/2
     @test D(x -> hankelh2(ν,x))(x) == (hankelh2(ν - 1, x) - hankelh2(ν + 1, x))/2
-    
+
     @test D(x -> polygamma(m,x))(x) == polygamma(m + 1, x)
-    
+
     @test D(x -> beta(x,y))(x) == beta(x,y)*(digamma(x)-digamma(x+y))
     @test D(y -> beta(x,y))(y) == beta(x,y)*(digamma(y)-digamma(x+y))
 
     @test D(x -> lbeta(x,y))(x) == digamma(x)-digamma(x+y)
     @test D(y -> lbeta(x,y))(y) == digamma(y)-digamma(x+y)
-    
+
     for (M, f, arity) in DiffRules.diffrules()
         if arity == 1 && (M == :Base || M == :SpecialFunctions) && f ∉ [:inv, :+, :-, :abs, ] # [:bessely0, :besselj0, :bessely1, :besselj1]
             deriv = DiffRules.diffrule(M, f, :x)
@@ -76,7 +76,7 @@ end
 
 @testset "   Euler-Lagrange Solver" begin
     function Γ(w)
-       t -> UpTuple((t, w(t), D(w)(t)))
+       t -> UpTuple([t, w(t), D(w)(t)])
     end
 
     function Lagrange_Equations(L)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,6 +74,25 @@ end
     end
 end
 
+@testset "   UpTuple and DownTuple" begin
+    # UpTuple
+    ut = UpTuple([x, x^2, -x-y])
+    @test ut == ut
+    @test string(ut) == "up(x\n   x ^ 2\n   (x + y) * -1)"
+    @test (ut(t)).data == [x(t), (x^2)(t), (-x-y)(t)]
+    @test string(ut(t)) == string(  UpTuple([x(t), (x^2)(t), (-x-y)(t)])  )
+    @test up(ut.data) == ut
+    @test ut[2] == x^2
+    ut[2] = y
+    @test y == ut[2]
+    @test ut.data == [x, y, -x-y]
+    # DownTuple
+    dt = DownTuple([x, x^2, -x-y])
+    @test dt == dt
+    @test (dt(t)).data == [x(t), (x^2)(t), (-x-y)(t)]
+    @test down(dt.data) == dt
+end
+
 @testset "   Euler-Lagrange Solver" begin
     function Γ(w)
        t -> UpTuple([t, w(t), D(w)(t)])


### PR DESCRIPTION
This PR is an attempt to fix #11. UpTuple and DownTuple are now wrappers around Vector (i.e., 1-dim Array), instead of Tuple, as is currently done. Tests seem to be passing, but I think it might be improved even more... is this kind of what you had in mind, @MasonProtter ?