### PR TITLE
Implemented LaTeX rendering of equations

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,6 @@
 julia 1.0
 Lazy v0.13.1
+LaTeXStrings v1.0.3
 DataStructures v0.14.0
 Match v1.0.1
 DiffRules v0.0.7

--- a/src/LaTeX.jl
+++ b/src/LaTeX.jl
@@ -1,0 +1,242 @@
+using LaTeXStrings
+using Printf
+
+# * User flags
+
+ABBREVIATE_POWER_OF_NEGATIVE_UNITY=false
+ADVANCE_DELIMITERS=true
+
+"""
+    abbreviate_power_of_negative_unity(flag)
+
+If `flag` is `true`, powers of `(-1)` will be printed as `(-)ᵖ`, if
+`false` as `(-1)ᵖ`.
+"""
+function abbreviate_power_of_negative_unity(flag::Bool)
+    global ABBREVIATE_POWER_OF_NEGATIVE_UNITY
+    ABBREVIATE_POWER_OF_NEGATIVE_UNITY=flag
+end
+
+"""
+    advance_delimiters(flag)
+
+If `flag` is `true`, nested delimiters will alternate as `{x + [y + (z
++ w)]}` to highlight the level of nesting; if `false`, the delimiters
+will not alternate: `(x + [y + (z + w)])`.
+"""
+function advance_delimiters(flag::Bool)
+    global ADVANCE_DELIMITERS
+    ADVANCE_DELIMITERS=flag
+end
+
+# * LaTeX conversion
+
+# ** Numbers
+
+function latex(sym::Symbolic)
+    sym_str = replace(replace("$(sym)", "{"=>"\\{"), "}"=>"\\}")
+    "\\textrm{$(sym_str)}",0
+end
+latex(s::Real) = "$(s)",0
+
+
+function base_exp(v::T) where {T<:AbstractFloat}
+    v == zero(T) && return (zero(T),0)
+    r = log10(abs(v))
+    e = floor(Int,r)
+    b = sign(v)*T(10)^(r-e)
+    b,e
+end
+
+function latex(s::AbstractFloat)
+    b,e = base_exp(s)
+    if abs(e) < 3
+        @sprintf("%0.10g", s)
+    else
+        "$b\\times10^{$e}"
+    end,0
+end
+
+function latex(z::Complex{T}) where T
+    a,b = real(z),imag(z)
+    la,lb = latex(a),latex(b)
+    sla,slb = if T == Bool
+        "",""
+    else
+        la[1],lb[1]
+    end
+    if a == zero(T)
+        slb * "\\mathrm{i}"
+    elseif b == zero(T)
+        sla
+    else
+        sla * (b < 0 ? "" : "+") * slb * "\\mathrm{i}"
+    end,max(la[2],lb[2])
+end
+latex(s::Sym) = "$(s)",0
+
+# ** Operators
+
+LaTeX_operators = Dict(:(+) => "+",
+                       :(-) => "-",
+                       :(*) => "",
+                       :(/) => "/",
+                       :(%) => "\\mod", # rem(::Symbolic) not implemented
+                       :log => "\\ln",
+                       :log10 => "\\log_{10}",
+                       :log2 => "\\log_2",
+                       :asin => "\\arcsin",
+                       :asinh => "\\operatorname{arcsinh}",
+                       :acos => "\\arccos",
+                       :acosh => "\\operatorname{arccosh}",
+                       :atan => "\\arctan",
+                       :atanh => "\\operatorname{arctanh}")
+
+# These functions have the same names in LaTeX
+LaTeX_functions = [:sin, :sinh,
+                   :cos, :cosh,
+                   :tan, :tanh,
+                   :exp,
+                   :min, :max,
+                   :mod,
+                   :sqrt]
+
+function latex_op(op::Sym)
+    if op.name in keys(LaTeX_operators)
+        LaTeX_operators[op.name]
+    elseif op.name in LaTeX_functions
+        "\\$(op.name)"
+    else
+        "$(op)"
+    end
+end
+
+latex_op(op) = latex(op)
+
+# ** Delimiters
+
+get_next_delim(max_delim) =
+    [("(",")"), ("[","]"), ("\\{", "\\}")][mod(max_delim,3)+1]
+
+function delimit(val, max_delim, doit::Bool=true)
+    !doit && return (val,max_delim)
+    a,b = get_next_delim(max_delim)
+    "\\left$(a)$(val)\\right$(b)", max_delim + (ADVANCE_DELIMITERS ? 1 : 0)
+end
+
+should_be_delimited(::Sym) = false
+should_be_delimited(::Number) = true
+should_be_delimited(r::Real) = isnegated(r)
+should_be_delimited(v::Vector) = length(v) > 1 || should_be_delimited(v[1])
+
+brace(s::String) = "{$(s)}"
+
+# ** Arguments
+
+function latex_arg(arg,should_delimit::Bool)
+    larg = latex(arg)
+    if should_delimit && (arg isa SymExpr && arg.op.name ∈ [:(+)] ||
+                         arg isa Complex ||
+                         arg isa Real && arg < 0)
+        delimit(larg...)
+    else
+        larg
+    end
+end
+
+latex_args(args::Vector,should_delimit::Bool) =
+    map(arg -> latex_arg(arg, should_delimit), args)
+
+latex_args(expr::SymExpr,should_delimit::Bool) =
+    latex_args(expr.args, should_delimit)
+
+latex_args(s::Number,::Bool) = [latex_arg(s, false)]
+
+# ** Expressions
+
+function latex(expr::SymExpr)
+    op = expr.op
+    lop = latex_op(op)
+    # The arguments need only be wrapped in delimiters for products
+    # and powers.
+    largs = latex_args(expr.args, op.name ∈ [:(*), :(^)])
+    max_delim = maximum(last.(largs))
+
+    if op.name == :(+)
+        S = first(largs[1])
+        for a in first.(largs[2:end])
+            S *= first(lstrip(a, ['{'])) == '-' ? "" : "+"
+            S *= a
+        end
+        S,max_delim
+    elseif op.name == :(^)
+        arg1 = expr.args[1]
+        earg2 = latex_arg(expr.args[2], false)
+        earg2s = "^{$(earg2[1])}"
+        # If the user has requested thus, (-1)^z will be printed as (-)^z
+        if ABBREVIATE_POWER_OF_NEGATIVE_UNITY &&
+            arg1 isa Number && !(arg1 isa SymExpr) && arg1 isa Real && arg1 == -1
+            "(-)$(earg2s)",max((ADVANCE_DELIMITERS ? 1 : 0),earg2[2])
+        elseif arg1 isa SymExpr && arg1.op.name ∉ [:(+), :(*), :(^), :sqrt]
+            larg1 = latex_args(arg1.args,false)
+            max_delim = max(maximum(last.(larg1)), earg2[2])
+            slarg1 = join(first.(larg1), ",")
+            if should_be_delimited(arg1.args)
+                slarg1,max_delim = delimit(slarg1,max_delim)
+            end
+            "$(latex_op(arg1.op))$(earg2s)$(slarg1)",max_delim
+        else
+            "$(largs[1][1])$(earg2s)",max(largs[1][2],earg2[2])
+        end
+    elseif op.name == :(*)
+        i = findfirst(isequal(-1), expr.args)
+        isneg = i !== nothing
+        expr = !isneg ? expr : prod(expr.args[vcat(1:i-1,i+1:length(expr.args))])
+
+        num = numerator(expr)
+        den = denominator(expr)
+
+        max_delim = 0
+        # If there is a factor -1, represent that as a prefactor -.
+        (isneg ? "-" : "")*if den == 1
+            # Only numerator
+            if num isa SymExpr && num.op.name == :(*)
+                nlargs = latex_args(num, true)
+                max_delim = maximum(last.(nlargs))
+                join(first.(nlargs),"")
+            else
+                # Dropping a possible -1 factor may have yielded an
+                # expression that is not a multiplication anymore.
+                nlarg,max_delim = delimit(latex(num)...,
+                                          isneg && should_be_delimited(num))
+                nlarg
+            end
+        else
+            # Fraction
+            lnum = latex(num)
+            lden = latex(den)
+            max_delim = max(lnum[2],lden[2])
+            "\\frac{$(lnum[1])}{$(lden[1])}"
+        end,max_delim
+    else
+        # Any other function
+        slargs = join(first.(largs), ",")
+
+        dargs,max_delim = if op.name != :sqrt && (length(largs) > 1 ||
+                                                 should_be_delimited(first(expr.args)))
+            delimit(slargs, max_delim)
+        else
+            brace(slargs),max_delim
+        end
+
+        "$(lop)$(dargs)",max_delim
+    end
+end
+
+# * Convert to LaTeXString, display
+
+Base.convert(::Type{LaTeXString}, s::S) where {S<:Symbolic} =
+    latexstring("\$$(latex(s)[1])\$")
+
+Base.show(io::IO, ::MIME"text/latex", s::S) where {S<:Symbolic} =
+    show(io, "text/latex", convert(LaTeXString, s))

--- a/src/Symbolics.jl
+++ b/src/Symbolics.jl
@@ -17,6 +17,7 @@ include("Simplification.jl")
 include("Calculus.jl")
 include("FunctionAlgebra.jl")
 include("Structure.jl")
+include("LaTeX.jl")
 
 
 export Sym, SymExpr, AbstractSym, AbstractSymExpr, @sym, Symbolic, D, ∂, simplify, UpTuple, DownTuple

--- a/test/algebra.jl
+++ b/test/algebra.jl
@@ -1,6 +1,7 @@
 using Symbolics, Test
+import Symbolics: isnegated, isdenominator
 
-@sym x y t
+@sym x y z t
 
 @testset "Construction of SymExprs" begin
     @test x(t) == SymExpr(x, [t])
@@ -27,4 +28,40 @@ end
 
 @testset "            Replacements" begin
     @test (x^2 + 2x)(x => y) == y^2 + 2y
+end
+
+@testset "        Helper functions" begin
+    @test !isnegated(x)
+    @test !isnegated(5)
+    @test isnegated(-5)
+    @test isnegated(-x)
+    @test isnegated(-sin(x))
+
+    @test !isdenominator(5)
+    @test !isdenominator(x)
+    @test isdenominator(1/x)
+
+    @test numerator(x) == x
+    @test denominator(x) == 1
+
+    @test numerator(1/x) == 1
+    @test denominator(1/x) == x
+
+    @test numerator(y*z/x) == y*z
+    @test denominator(y*z/x) == x
+
+    @test numerator(x/(y*z)) == x
+    @test denominator(x/(y*z)) == y*z
+
+    @test numerator(1/-x) == 1
+    @test denominator(1/-x) == -x
+
+    @test numerator(1/sin(x)) == 1
+    @test denominator(1/sin(x)) == sin(x)
+
+    @test numerator(1/-sin(x)) == 1
+    @test denominator(1/-sin(x)) == -sin(x)
+
+    @test numerator(z/(-y*sin(x))) == z
+    @test denominator(z/(-y*sin(x))) == -y*sin(x)
 end

--- a/test/latex.jl
+++ b/test/latex.jl
@@ -1,0 +1,50 @@
+using Symbolics, Test
+import Symbolics: latex
+
+@testset "LaTeX rendering" begin
+    @sym x y z
+
+    Symbolics.abbreviate_power_of_negative_unity(true)
+    @test latex((-1)^x) == ("(-)^{x}", 1)
+
+    Symbolics.abbreviate_power_of_negative_unity(false)
+    @test latex((-1)^x) == ("\\left(-1\\right)^{x}", 1)
+
+    Symbolics.abbreviate_power_of_negative_unity(true)
+    f=sin(x^3)
+    @test latex(f) == ("\\sin\\left(x^{3}\\right)", 1)
+    g′=x/(-z)
+    @test latex(g′) == ("\\frac{x}{-z}", 0)
+    g=x/-sin(z)
+    @test latex(g) == ("\\frac{x}{-\\left(\\sin{z}\\right)}", 1)
+    @test latex(x/((x+y+z)^4)) == ("\\frac{x}{\\left(x+y+z\\right)^{4}}", 1)
+    @test latex(x/(sin(z)^4)) == ("\\frac{x}{\\sin^{4}z}", 0)
+    @test latex(x/(sin(y+z)^4)) == ("\\frac{x}{\\sin^{4}\\left(y+z\\right)}", 1)
+    @test latex(x/(sin(y+z))) == ("\\frac{x}{\\sin\\left(y+z\\right)}", 1)
+    @test latex(x/(sin(z)^(y+x))) == ("\\frac{x}{\\sin^{y+x}z}", 0)
+    @test latex(x + im) == ("x+\\mathrm{i}", 0)
+    h=cos(f+g)
+    @test latex(h) == ("\\cos\\left[\\sin\\left(x^{3}\\right)+\\frac{x}{-\\left(\\sin{z}\\right)}\\right]", 2)
+
+    Symbolics.advance_delimiters(false)
+    @test latex(cos((-1)^x+sin(h))) == ("\\cos\\left((-)^{x}+\\sin\\left(\\cos\\left(\\sin\\left(x^{3}\\right)+\\frac{x}{-\\left(\\sin{z}\\right)}\\right)\\right)\\right)", 0)
+
+    Symbolics.advance_delimiters(true)
+    @test latex(cos((-1)^x+sin(h))) == ("\\cos\\left((-)^{x}+\\sin\\left\\{\\cos\\left[\\sin\\left(x^{3}\\right)+\\frac{x}{-\\left(\\sin{z}\\right)}\\right]\\right\\}\\right)", 4)
+    @test latex(cos((-1)^x+f)) == ("\\cos\\left[(-)^{x}+\\sin\\left(x^{3}\\right)\\right]", 2)
+
+    @test latex(cos((-1)^(2x+y*(z+cos(x)))+sin(h))) == ("\\cos\\left((-)^{2x+y\\left(z+\\cos{x}\\right)}+\\sin\\left\\{\\cos\\left[\\sin\\left(x^{3}\\right)+\\frac{x}{-\\left(\\sin{z}\\right)}\\right]\\right\\}\\right)", 4)
+    @test latex(cos((-1)^(2x+y*(z+cos(x)))+f)) == ("\\cos\\left[(-)^{2x+y\\left(z+\\cos{x}\\right)}+\\sin\\left(x^{3}\\right)\\right]", 2)
+    @test latex(x-y-z+x^(2y+4z*(y+x))) == ("-\\left(y+z\\right)+x+x^{2y+4z\\left(y+x\\right)}", 1)
+    @test latex(asinh(x+sin(y))) == ("\\operatorname{arcsinh}\\left(x+\\sin{y}\\right)", 1)
+    @test latex(log10(x)+log(x)+log2(x)) == ("\\log_{10}{x}+\\ln{x}+\\log_2{x}", 0)
+    @test latex(√x) == ("\\sqrt{x}", 0)
+    @test latex(√(x+y)) == ("\\sqrt{x+y}", 0)
+    @test latex(sin(x/y)) == ("\\sin\\left(\\frac{x}{y}\\right)", 1)
+    @test latex(cos(sin(x/y))) == ("\\cos\\left[\\sin\\left(\\frac{x}{y}\\right)\\right]", 2)
+    @test latex(sin(-x)) == ("\\sin\\left(-x\\right)", 1)
+    @test latex(exp(-x/y)) == ("\\exp\\left(-\\frac{x}{y}\\right)", 1)
+    @test latex(exp(x/-y)) == ("\\exp\\left(\\frac{x}{-y}\\right)", 1)
+
+    @test latex(1e-17x) == ("1.0\\times10^{-17}x",0)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,8 @@ testfiles = (
     "algebra.jl",
     "derivatives.jl",
     "structures.jl",
-    "eulerlagrange.jl"
+    "eulerlagrange.jl",
+    "latex.jl",
     )
 
 for file in testfiles


### PR DESCRIPTION
Some features illustrated below:

Optional abbreviation of `(-1)^p` to `(-)^p` (off by default, since it can be confusing):
<img width="521" alt="image" src="https://user-images.githubusercontent.com/117947/51085897-acbda900-173f-11e9-9092-bbc3e91eec49.png">

Automatic cycling of delimiters at different levels of nesting (on by default):
<img width="394" alt="image" src="https://user-images.githubusercontent.com/117947/51085926-1b9b0200-1740-11e9-92dc-214f6fef8027.png">
When the function `g` is displayed above, the minus sign remains in the denominator, since I think it is up to the simplification to move it to the numerator.

There are more functions that could be given proper LaTeX representations, e.g. `besselj` is printed like this at the moment:
<img width="301" alt="image" src="https://user-images.githubusercontent.com/117947/51085980-e4792080-1740-11e9-8522-53e346dcf104.png">

To be able to display fractions properly, I also implemented `numerator` and `denominator` for `SymExpr` arguments.